### PR TITLE
PHP memory limit set to 256M for both environments

### DIFF
--- a/api/docker/php/conf.d/api-platform.dev.ini
+++ b/api/docker/php/conf.d/api-platform.dev.ini
@@ -2,6 +2,7 @@ apc.enable_cli = 1
 date.timezone = UTC
 session.auto_start = Off
 short_open_tag = Off
+memory_limit = 256M
 
 # https://symfony.com/doc/current/performance.html
 opcache.interned_strings_buffer = 16

--- a/api/docker/php/conf.d/api-platform.prod.ini
+++ b/api/docker/php/conf.d/api-platform.prod.ini
@@ -3,6 +3,7 @@ date.timezone = UTC
 session.auto_start = Off
 short_open_tag = Off
 expose_php = Off
+memory_limit = 256M
 
 # https://symfony.com/doc/current/performance.html
 opcache.interned_strings_buffer = 16


### PR DESCRIPTION
128M (default) being too low to run phpunit tests locally (make phpunit)