### PR TITLE
Don't recreate symbolic link if exist

### DIFF
--- a/front/docker-entrypoint-example.sh
+++ b/front/docker-entrypoint-example.sh
@@ -10,8 +10,14 @@ echo 'pwa is up'
 if [ -d gally-admin ]
 then
   cd example-app/node_modules
-  ln -s ../../gally-admin/packages/components gally-admin-components
-  ln -s ../../gally-admin/packages/shared gally-admin-shared
+  if [ ! -f gally-admin-components ]
+  then
+  	ln -s ../../gally-admin/packages/components gally-admin-components
+  fi
+  if [ ! -f gally-admin-shared ]
+  then
+  	ln -s ../../gally-admin/packages/shared gally-admin-shared
+  fi
   cd ../..
 fi
 

--- a/front/docker-entrypoint-pwa.sh
+++ b/front/docker-entrypoint-pwa.sh
@@ -10,8 +10,14 @@ then
   yarn install --frozen-lockfile;
   yarn build
   cd ../pwa/node_modules
-  ln -s ../../gally-admin/packages/components gally-admin-components
-  ln -s ../../gally-admin/packages/shared gally-admin-shared
+  if [ ! -f gally-admin-components ]
+  then
+  	ln -s ../../gally-admin/packages/components gally-admin-components
+  fi
+  if [ ! -f gally-admin-shared ]
+  then
+  	ln -s ../../gally-admin/packages/shared gally-admin-shared
+  fi
   cd ../..
 fi
 


### PR DESCRIPTION
If I up the docker multiple time, I can have a new symbolic link in front/gally-components/components that point to nothing