### PR TITLE
ESPP-18 Remove bulkIndex structure requirement

### DIFF
--- a/api/src/Elasticsuite/Standard/src/Index/Dto/Bulk/Request.php
+++ b/api/src/Elasticsuite/Standard/src/Index/Dto/Bulk/Request.php
@@ -47,7 +47,7 @@ class Request
     /**
      * Add a single document to the index.
      */
-    public function addDocument(Index $index, string|int $docId, array $data): self
+    public function addDocument(Index $index, string|int|null $docId, array $data): self
     {
         $this->bulkData[] = ['index' => ['_index' => $index->getName(), '_type' => '_doc', '_id' => $docId]];
         $this->bulkData[] = $data;
@@ -57,13 +57,13 @@ class Request
 
     /**
      * Add a several documents to the index.
-     * $data format have to be an array of all documents with document id as key.
      */
     public function addDocuments(Index $index, array $data): self
     {
         array_walk(
             $data,
-            function ($documentData, $identifier) use ($index) {
+            function ($documentData) use ($index) {
+                $identifier = $documentData['entity_id'] ?? $documentData['id'] ?? null;
                 $this->addDocument($index, $identifier, $documentData);
             }
         );

--- a/api/src/Elasticsuite/Standard/src/Index/Repository/Document/DocumentRepository.php
+++ b/api/src/Elasticsuite/Standard/src/Index/Repository/Document/DocumentRepository.php
@@ -34,7 +34,7 @@ class DocumentRepository implements DocumentRepositoryInterface
             $params['body'][] = [
                 'index' => [
                     '_index' => $indexName,
-                    '_id' => $document['entity_id'] ?? $document['id'],
+                    '_id' => $document['entity_id'] ?? $document['id'] ?? null,
                 ],
             ];
 

--- a/api/src/Elasticsuite/Standard/src/Index/Tests/Api/GraphQl/IndexOperationsBulkTest.php
+++ b/api/src/Elasticsuite/Standard/src/Index/Tests/Api/GraphQl/IndexOperationsBulkTest.php
@@ -73,16 +73,16 @@ class IndexOperationsBulkTest extends AbstractTest
         $admin = $this->getUser(Role::ROLE_ADMIN);
         $indexName = ElasticsearchFixturesInterface::PREFIX_TEST_INDEX . 'index_product';
         $documents = [
-            'id1' => ['name' => 'Test doc 1', 'size' => 12],
-            'id2' => ['name' => 'Test doc 2', 'size' => 8],
-            'id3' => ['name' => 'Test doc 3', 'size' => 5],
+            'id1' => ['id' => 'id1', 'name' => 'Test doc 1', 'size' => 12],
+            'id2' => ['id' => 'id2', 'name' => 'Test doc 2', 'size' => 8],
+            'id3' => ['id' => 'id3', 'name' => 'Test doc 3', 'size' => 5],
         ];
 
         yield [$indexName, $documents, $this->getUser(Role::ROLE_CONTRIBUTOR), ['errors' => [['debugMessage' => 'Access Denied.']]]];
         yield [$indexName, $documents, $admin, ['data' => ['bulkIndex' => ['index' => ['name' => $indexName]]]]];
         yield ['wrongName', $documents, $admin, ['errors' => [['debugMessage' => 'Index with name [wrongName] does not exist']]]];
 
-        $documents['id2'] = ['name' => 'Test doc 2', 'size' => 'wrongSize'];
+        $documents['id2'] = ['id' => 'id2', 'name' => 'Test doc 2', 'size' => 'wrongSize'];
         $message = sprintf(
             'Bulk index operation failed %d times in index %s. ' .
             'Error (mapper_parsing_exception) : failed to parse field [size] of type [integer] in document with id \'id2\'. ' .


### PR DESCRIPTION
of having the document id as key of the documents array. This mirrors what was already done in the document repository, used by fixtures.