### PR TITLE
Run pecl channel-update to get latest channel updates

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -62,6 +62,7 @@ RUN set -eux; \
 
 # PHP Redis install
 RUN apk add --no-cache pcre-dev $PHPIZE_DEPS \
+	&& pecl update-channels \
 	&& pecl install redis \
     && docker-php-ext-enable redis.so
 


### PR DESCRIPTION
I tried rebuilding the Docker containers today and the PHP container constantly failed building. The `pecl install redis` command complained:
```
No releases available for package "pecl.php.net/redis"
```

After adding the `pecl update-channels` to the Dockerfile, I could build the containers again. Not sure if this is a local problem or a  problem with my internet connection.
