### PR TITLE
Fix icon-material timeout on Yarn install

### DIFF
--- a/front/Dockerfile
+++ b/front/Dockerfile
@@ -19,7 +19,7 @@ ENV NEXT_TELEMETRY_DISABLED 1
 COPY . ./
 
 RUN set -xe; \
-	yarn install --frozen-lockfile; \
+	yarn install --frozen-lockfile --network-timeout 120000; \
     yarn cache clean;
 
 

--- a/front/docker-entrypoint-pwa.sh
+++ b/front/docker-entrypoint-pwa.sh
@@ -2,12 +2,12 @@
 
 fixuid || :
 
-yarn install --frozen-lockfile
+yarn install --frozen-lockfile --network-timeout 120000
 
 if [ -d gally-admin ]
 then
   cd gally-admin
-  yarn install --frozen-lockfile;
+  yarn install --frozen-lockfile --network-timeout 120000;
   yarn build
   yarn cache clean
   cd node_modules


### PR DESCRIPTION
Exemple of error : https://github.com/Elastic-Suite/gally/actions/runs/7057157646/job/19210321734
Fix source : https://github.com/yarnpkg/yarn/issues/8754
