### PR TITLE
Create lexik key on fisrt deploy

### DIFF
--- a/.github/workflows/deploy-int.yml
+++ b/.github/workflows/deploy-int.yml
@@ -69,6 +69,7 @@ jobs:
             ([[ $(docker volume ls -q | awk '!/_/' | wc -l) -eq 0 ]] || docker volume rm $(docker volume ls -q | awk '!/_/' | tr '\n' ' ')) &&
             make .env &&
             POSTGRES_PASSWORD=$POSTGRES_PASSWORD docker compose -f compose.yml -f compose.int.yml up -d database && 
+            POSTGRES_PASSWORD=$POSTGRES_PASSWORD docker compose -f compose.yml run --rm bin/console lexik:jwt:generate-keypair --skip-if-exists && 
             docker compose -f compose.yml -f compose.int.yml down &&
             git fetch --all && git reset --hard  && git checkout ${{ env.back_branch }} &&
             [ -d front/gally-admin ] || git clone https://github.com/Elastic-Suite/gally-admin.git front/gally-admin &&


### PR DESCRIPTION
On the first deployment with the github action we need to create ssl key pair for lexit but we can't create it without the postgre password, so it is easier to include it in the deploy script to run it each time with the `--skip-if-exists` option